### PR TITLE
set_webhook management command

### DIFF
--- a/mpact_api/manage-dev.example
+++ b/mpact_api/manage-dev.example
@@ -5,4 +5,9 @@ export TOKEN=1234567890:oMM9WNHx_7RlUYstgg36hEAeqg0QoPAKHsw
 export BOT_USERNAME=rodney_copperbot
 export ALLOWED_HOSTS='127.0.0.1 localhost'
 
+if [ -f api-server ] ; then
+    # If api-server script is created, assume we're running a local API
+    export API_BASE_URL=http://localhost:8081/bot
+fi
+
 python3 manage.py $*

--- a/mpact_api/mpact/management/commands/set_webhook.py
+++ b/mpact_api/mpact/management/commands/set_webhook.py
@@ -1,0 +1,22 @@
+import os
+
+from django.core.management import BaseCommand
+from django.urls import reverse
+
+from mpact.constants import MESSAGE
+from mpact.services import updater
+
+
+class Command(BaseCommand):
+    help = ('Set the URL to receive incoming updates from Telegram.')
+
+    def handle(self, *args, **options):
+        success = set_webhook()
+        print('OK' if success else 'Unable to set webhook')
+
+
+def set_webhook() -> bool:
+    local_url = 'http://localhost:8000' + reverse("listen_msg")
+    webhook_url = os.environ.get('WEBHOOK_URL') or local_url
+    success = updater.bot.setWebhook(webhook_url, allowed_updates=[MESSAGE])
+    return success

--- a/mpact_api/mpact/services.py
+++ b/mpact_api/mpact/services.py
@@ -1,6 +1,10 @@
+import os
+
+from django.urls import reverse
+
 from telegram.ext import Updater
 
-from .constants import BOT_TOKEN, ID, MESSAGE, REPLACE, WEBHOOK_URL
+from .constants import BOT_TOKEN, ID, MESSAGE, REPLACE
 from .models import UserChat, UserData
 from .serializers import ChatDataSerializer, UserDataSerializer
 
@@ -8,10 +12,12 @@ updater = Updater(BOT_TOKEN, use_context=True)
 dispatcher = updater.dispatcher
 
 
-def set_webhook():
+def set_webhook() -> bool:
     # TODO: we can move this to config file or keep this as a seperate script.
-    webhook = updater.bot.setWebhook(WEBHOOK_URL, allowed_updates=[MESSAGE])
-    return webhook  # returns True or False
+    local_url = 'http://localhost:8000' + reverse("listen_msg")
+    webhook_url = os.environ.get('WEBHOOK_URL') or local_url
+    success = updater.bot.setWebhook(webhook_url, allowed_updates=[MESSAGE])
+    return success
 
 
 def save_chatdata(chat_data, chat_instance=None):

--- a/mpact_api/mpact/services.py
+++ b/mpact_api/mpact/services.py
@@ -1,23 +1,11 @@
-import os
-
-from django.urls import reverse
-
 from telegram.ext import Updater
 
-from .constants import BOT_TOKEN, ID, MESSAGE, REPLACE
+from .constants import BOT_TOKEN, ID, REPLACE
 from .models import UserChat, UserData
 from .serializers import ChatDataSerializer, UserDataSerializer
 
 updater = Updater(BOT_TOKEN, use_context=True)
 dispatcher = updater.dispatcher
-
-
-def set_webhook() -> bool:
-    # TODO: we can move this to config file or keep this as a seperate script.
-    local_url = 'http://localhost:8000' + reverse("listen_msg")
-    webhook_url = os.environ.get('WEBHOOK_URL') or local_url
-    success = updater.bot.setWebhook(webhook_url, allowed_updates=[MESSAGE])
-    return success
 
 
 def save_chatdata(chat_data, chat_instance=None):

--- a/mpact_api/mpact/services.py
+++ b/mpact_api/mpact/services.py
@@ -1,11 +1,11 @@
+from django.conf import settings
 from telegram.ext import Updater
 
 from .constants import BOT_TOKEN, ID, REPLACE
 from .models import UserChat, UserData
 from .serializers import ChatDataSerializer, UserDataSerializer
 
-updater = Updater(BOT_TOKEN, use_context=True)
-dispatcher = updater.dispatcher
+updater = Updater(BOT_TOKEN, base_url=settings.API_BASE_URL, use_context=True)
 
 
 def save_chatdata(chat_data, chat_instance=None):

--- a/mpact_api/mpact/urls.py
+++ b/mpact_api/mpact/urls.py
@@ -4,5 +4,5 @@ from . import views
 
 urlpatterns = [
     path("set_webhook", views.Webhook.as_view()),
-    path("listen_msg", views.ListenMessages.as_view()),
+    path("listen_msg", views.ListenMessages.as_view(), name="listen_msg"),
 ]

--- a/mpact_api/mpact/urls.py
+++ b/mpact_api/mpact/urls.py
@@ -3,6 +3,5 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("set_webhook", views.Webhook.as_view()),
     path("listen_msg", views.ListenMessages.as_view(), name="listen_msg"),
 ]

--- a/mpact_api/mpact/views.py
+++ b/mpact_api/mpact/views.py
@@ -4,7 +4,8 @@ from rest_framework.views import APIView
 
 from .constants import MESSAGE, NEW_CHAT_PARTICIPANT, NEW_CHAT_TITLE, OK, TEXT
 from .logger import logger
-from .services import anonymize, set_webhook
+from .services import anonymize
+from .management.commands.set_webhook import set_webhook
 from .telegramevents import TelegramEvents
 
 
@@ -14,8 +15,8 @@ class Webhook(APIView):
     """
 
     def get(self, request):
-        webhook = set_webhook()
-        if webhook:
+        success = set_webhook()
+        if success:
             return Response("webhook setup ok")
         else:
             return Response("webhook setup failed")

--- a/mpact_api/mpact/views.py
+++ b/mpact_api/mpact/views.py
@@ -5,21 +5,7 @@ from rest_framework.views import APIView
 from .constants import MESSAGE, NEW_CHAT_PARTICIPANT, NEW_CHAT_TITLE, OK, TEXT
 from .logger import logger
 from .services import anonymize
-from .management.commands.set_webhook import set_webhook
 from .telegramevents import TelegramEvents
-
-
-class Webhook(APIView):
-    """
-    This is only called once for the webhook setup.
-    """
-
-    def get(self, request):
-        success = set_webhook()
-        if success:
-            return Response("webhook setup ok")
-        else:
-            return Response("webhook setup failed")
 
 
 class ListenMessages(APIView):

--- a/mpact_api/telegram_bot/settings.py
+++ b/mpact_api/telegram_bot/settings.py
@@ -22,6 +22,9 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ["SECRET_KEY"]
 
+# API_BASE_URL defaults to telegram.Bot.base_url default value
+API_BASE_URL = os.environ.get("API_BASE_URL") or "https://api.telegram.org/bot"
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 


### PR DESCRIPTION
This PR changes how the webhook and API URLs are treated, to allow local dev environment to use a local Telegram Bot API server:

1. WEBHOOK_URL becomes an environment variable. If it is not set, it defaults to the `ListenMessages` view on localhost.

2. API_BASE_URL is a new environment variable. It points to the local Telegram Bot API server if the script to use it has been created, otherwise it points to the cloud Telegram Bot API server.

3. The `mpact.services.set_webhook()` function moves to a management command, and the view is removed. Set the webhook URL with:

       $ ./manage-dev set_webhook

   For a production environment, this command should be run at the end of the initial deploy.

@hussain-mohammed 